### PR TITLE
Fix for xmp error while interpreting

### DIFF
--- a/backgroundscript.js
+++ b/backgroundscript.js
@@ -33,7 +33,7 @@ browser.contextMenus.onClicked.addListener((info, tab) => {
         return browser.tabs.executeScript(null, {
           file: script
         });
-      })
+      });
 
       Promise.all(scriptLoadPromises).then(() => {
         browser.tabs.sendMessage(tab.id, {

--- a/binExif.js
+++ b/binExif.js
@@ -856,7 +856,7 @@ Real MN-Offset: 0x0356
           case 3:
             dataObj.MeteringMode = stringBundle.getString("spot");
             break;
-          case 3:
+          case 4:
             dataObj.MeteringMode = stringBundle.getString("multispot");
             break;
           case 5:

--- a/contentscript.js
+++ b/contentscript.js
@@ -12,7 +12,7 @@ function addByteStreamIF(arr) {
     var val = arr[arr.bisOffset] << 8 | arr[arr.bisOffset + 1];
     arr.bisOffset += 2;
     return val;
-  }
+  };
   arr.readBytes = byteCount => {
     var retval = "";
     for (var i = 0; i < byteCount; i++) {
@@ -20,7 +20,7 @@ function addByteStreamIF(arr) {
       arr.bisOffset++;
     }
     return retval;
-  }
+  };
   arr.readByteArray = len => {
     var retval = arr.subarray(arr.bisOffset, arr.bisOffset + len);
     arr.bisOffset += len;

--- a/fxifUtils.js
+++ b/fxifUtils.js
@@ -26,7 +26,7 @@ function fxifUtilsClass ()
       return (data[offset] << 8) | data[offset+1];
 
     return data[offset] | (data[offset+1] << 8);
-  }
+  };
 
   this.read32 = function (data, offset, swapbytes)
   {
@@ -34,7 +34,7 @@ function fxifUtilsClass ()
       return (data[offset] << 24) | (data[offset+1] << 16) | (data[offset+2] << 8) | data[offset+3];
 
     return data[offset] | (data[offset+1] << 8) | (data[offset+2] << 16) | (data[offset+3] << 24);
-  }
+  };
 
   /* charWidth should normally be 1 and this function thus reads
    * the bytes one by one. But reading Unicode needs reading
@@ -69,7 +69,7 @@ function fxifUtilsClass ()
     }
 
     return s;
-  }
+  };
 
   /* Doesn’t stop at null bytes. */
   this.bytesToStringWithNull = function (data, offset, num)
@@ -80,7 +80,7 @@ function fxifUtilsClass ()
       s += String.fromCharCode(data[i]);
 
     return s;
-  }
+  };
 
   this.dd2dms = function (gpsval)
   {
@@ -92,7 +92,7 @@ function fxifUtilsClass ()
     // round to 2 digits after the comma
     var gpsSec = (gpsval - gpsMin * 60.0).toFixed(2);
     return new Array(gpsDeg, gpsMin, gpsSec);
-  }
+  };
 
   this.dd2dm = function (gpsval)
   {
@@ -103,7 +103,7 @@ function fxifUtilsClass ()
     // round to 2 digits after the comma
     var gpsMin = (gpsval / 60).toFixed(4);
     return new Array(gpsDeg, gpsMin);
-  }
+  };
 
   this.dd2dd = function (gpsval)
   {
@@ -111,12 +111,12 @@ function fxifUtilsClass ()
     var gpsArr = new Array();
     gpsArr.push((gpsval / 3600).toFixed(6));
     return gpsArr;
-  }
+  };
 
   this.getPreferences = function ()
   {
     // console.log("getPreferences");
-  }
+  };
 
   // Retrieves the language which is likely to be the users favourite one.
   // Currently we end up using only the first language code.

--- a/parseJpeg.js
+++ b/parseJpeg.js
@@ -112,7 +112,7 @@ function fxifClass() {
     }
 
     return dataObj;
-  }
+  };
 
   function pushError(dataObj, type, message)
   {

--- a/popup/popupscript.js
+++ b/popup/popupscript.js
@@ -21,7 +21,7 @@ browser.runtime.sendMessage({
       href = href.replace(/%lon%/, response.GPSPureDdLon);
       href = href.replace(/%lang%/, browser.i18n.getUILanguage());
       window.open(href);
-    }
+    };
     var btns = document.getElementById("buttonzone");
     btns.insertBefore(mapbutton, btns.childNodes[0]);
   }

--- a/xmp.js
+++ b/xmp.js
@@ -56,7 +56,8 @@ function xmpClass()
 
       if (dom.documentElement.nodeName == 'parsererror') {
         console.error("Error parsing XML");
-        throw ("Error parsing XML");
+        // no known remedy, so don’t throw this problem
+        // throw ("Error parsing XML");
         return;
       }
     }

--- a/xmp.js
+++ b/xmp.js
@@ -475,7 +475,7 @@ function xmpClass()
           case 3:
             dataObj.MeteringMode = stringBundle.getString("spot");
             break;
-          case 3:
+          case 4:
             dataObj.MeteringMode = stringBundle.getString("multispot");
             break;
           case 5:

--- a/xmp.js
+++ b/xmp.js
@@ -35,8 +35,12 @@ function xmpClass()
     
     let utf8decoder = new TextDecoder('utf-8');
     let xmlString = utf8decoder.decode(xml);
-    var dom = parser.parseFromString(xmlString, 'application/xml');
     //console.debug("xmp xmlString: \n" + xmlString);
+    if (xmlString.charCodeAt(xmlString.length-1) == 0) {
+      xmlString = xmlString.substring(0,xmlString.length-1);
+      //console.debug("xmp xmlString modified: \n" + xmlString);
+    }
+
 
     if (dom.documentElement.nodeName == 'parsererror') {
       // parsererror might have been caused by incorrect encoding of characters.

--- a/xmp.js
+++ b/xmp.js
@@ -28,10 +28,15 @@ function xmpClass()
     var parser = new DOMParser();
     // There is at least one programm which includes a null byte at the end of the document.
     // The parser doesn't like this, so shorten the length by one byte of the last one is null.
-    var doclength = xml.length;
-    if (xml.length > 1 && xml[xml.length - 1] == 0)
-      doclength--;
-    var dom = parser.parseFromBuffer(xml, doclength, 'text/xml');
+    //var doclength = xml.length;
+    //if (xml.length > 1 && xml[xml.length - 1] == 0)
+    //  doclength--;
+    //var dom = parser.parseFromBuffer(xml, doclength, 'text/xml');
+    
+    let utf8decoder = new TextDecoder('utf-8');
+    let xmlString = utf8decoder.decode(xml);
+    var dom = parser.parseFromString(xmlString, 'application/xml');
+    //console.debug("xmp xmlString: \n" + xmlString);
 
     if (dom.documentElement.nodeName == 'parsererror') {
       // parsererror might have been caused by incorrect encoding of characters.
@@ -51,7 +56,7 @@ function xmpClass()
 
       if (dom.documentElement.nodeName == 'parsererror') {
         console.error("Error parsing XML");
-        // no known remedy, so don’t throw this problem
+        throw ("Error parsing XML");
         return;
       }
     }

--- a/xmp.js
+++ b/xmp.js
@@ -105,7 +105,7 @@ function xmpClass()
     var lang = fxifUtils.getLang();
     // Build a regular expression to be used to test the language
     // alternatives available in the XMP.
-    var langTest = new RegExp("^"+lang.match(/^[a-z]{2,3}/i), "i")
+    var langTest = new RegExp("^"+lang.match(/^[a-z]{2,3}/i), "i");
 
     if (!dataObj.Headline)
     {
@@ -677,7 +677,7 @@ function xmpClass()
       dataObj.GPSPureDdLat = gpsLat / 3600;
       dataObj.GPSPureDdLon = gpsLon / 3600;
     }
-  }
+  };
 
   // Parse a GPS datum.
   // It's stored like 49,9.8672N

--- a/xmp.js
+++ b/xmp.js
@@ -40,7 +40,7 @@ function xmpClass()
       xmlString = xmlString.substring(0,xmlString.length-1);
       //console.debug("xmp xmlString modified: \n" + xmlString);
     }
-
+    var dom = parser.parseFromString(xmlString, 'application/xml');
 
     if (dom.documentElement.nodeName == 'parsererror') {
       // parsererror might have been caused by incorrect encoding of characters.

--- a/xmp.js
+++ b/xmp.js
@@ -36,7 +36,7 @@ function xmpClass()
     let utf8decoder = new TextDecoder('utf-8');
     let xmlString = utf8decoder.decode(xml);
     //console.debug("xmp xmlString: \n" + xmlString);
-    if (xmlString.charCodeAt(xmlString.length-1) == 0) {
+    if (xmlString && xmlString.length>0 && xmlString.charCodeAt(xmlString.length-1) == 0) {
       xmlString = xmlString.substring(0,xmlString.length-1);
       //console.debug("xmp xmlString modified: \n" + xmlString);
     }


### PR DESCRIPTION
This should fix issue #1 .
I'm no expert on parsing, but this seems to work in all my tests. And it is definitely better than trying to call a method that doesn't exist anymore (parser.parseFromBuffer).